### PR TITLE
Fix render deployment errors

### DIFF
--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -39,6 +39,9 @@ class _LazyNotion:
 
 # Exported symbol used across the app:
 notion = _LazyNotion()
+
+# Add the new environment variable for the output database ID
+OUTPUT_DB_ID = os.getenv("NOTION_OUTPUT_DB_ID")
 # ────────────────────────────────────────────────────────────────────
 def query_database(database_id):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core dependencies
 flask>=3.1.1
+setuptools>=65.5.1
 python-dotenv>=1.1.1
 requests>=2.32.4
 notion-client>=2.2.1

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -48,6 +48,7 @@ def check_environment_variables():
         'NOTION_TOKEN': os.getenv('NOTION_TOKEN'),
         'NOTION_PACKING_GUIDE_ID': os.getenv('NOTION_PACKING_GUIDE_ID'),
         'NOTION_WARDROBE_DB_ID': os.getenv('NOTION_WARDROBE_DB_ID'),
+        'NOTION_OUTPUT_DB_ID': os.getenv('NOTION_OUTPUT_DB_ID'),
         'GEMINI_AI_API_KEY': os.getenv('GEMINI_AI_API_KEY'),
         'GROQ_AI_API_KEY': os.getenv('GROQ_AI_API_KEY')
     }


### PR DESCRIPTION
This commit fixes two errors that were occurring in the Render deployment environment.

The first error was `cannot import name 'OUTPUT_DB_ID' from 'data.notion_utils'`. This was caused by the `OUTPUT_DB_ID` variable not being defined. This has been fixed by loading it from the `NOTION_OUTPUT_DB_ID` environment variable. The environment variable check at startup has also been updated to include this new variable.

The second error was `No module named 'distutils'`. This error is caused by the deprecation and removal of `distutils` in Python 3.12. The `psutil` library was relying on it. This has been fixed by adding `setuptools` to the `requirements.txt` file, which provides a replacement for `distutils`.