### PR TITLE
fix: Correct system monitor import error

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -14,8 +14,8 @@ def get_system_monitor():
     global _system_monitor
     if _system_monitor is None:
         try:
-            from .system_monitor import system_monitor
-            _system_monitor = system_monitor
+            from .system_monitor import enhanced_system_monitor
+            _system_monitor = enhanced_system_monitor
             logging.info("✅ System monitor loaded successfully")
         except ImportError as e:
             logging.warning(f"System monitor not available (ImportError): {e}")

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -98,8 +98,8 @@ def _get_core_functions():
 def _get_monitoring():
     """Lazy load monitoring components to avoid circular imports."""
     try:
-        from monitoring.system_monitor import system_monitor
-        return system_monitor
+        from monitoring import get_system_monitor
+        return get_system_monitor()
     except ImportError as e:
         logging.warning(f"System monitor not available: {e}")
         return None


### PR DESCRIPTION
The webhook server was failing to import the system monitor due to an incorrect object name (`system_monitor` instead of `enhanced_system_monitor`).

This commit corrects the import statement in `monitoring/__init__.py` and updates the webhook server to use the `get_system_monitor` helper function for more robust loading.