### PR TITLE
feat: Implement 'Send to Hamper' workflow

### DIFF
--- a/core/hamper_pipeline_orchestrator.py
+++ b/core/hamper_pipeline_orchestrator.py
@@ -1,0 +1,51 @@
+import logging
+from data.notion_utils import (
+    get_checked_items_from_page,
+    add_items_to_dirty_clothes_db,
+    uncheck_hamper_trigger
+)
+
+class HamperPipelineOrchestrator:
+    """
+    Orchestrates the "Send to Hamper" workflow.
+    """
+
+    def __init__(self):
+        pass
+
+    async def run_hamper_pipeline(self, page_id: str):
+        """
+        Main pipeline for the "Send to Hamper" workflow.
+        """
+        try:
+            logging.info(f"🧺 Starting 'Send to Hamper' pipeline for page {page_id}...")
+
+            # 1. Get checked items from the page
+            checked_items = get_checked_items_from_page(page_id)
+            if not checked_items:
+                logging.warning("No checked items found to send to hamper.")
+                # Still need to uncheck the trigger
+                uncheck_hamper_trigger(page_id)
+                return {"success": True, "message": "No items to send to hamper."}
+
+            # 2. Add items to the "Dirty Clothes" database
+            add_items_to_dirty_clothes_db(checked_items, page_id)
+
+            # 3. Uncheck the "Send to Hamper" trigger
+            uncheck_hamper_trigger(page_id)
+
+            logging.info(f"✅ 'Send to Hamper' pipeline completed successfully for page {page_id}.")
+            return {"success": True}
+
+        except Exception as e:
+            logging.error(f"❌ Critical pipeline error in 'Send to Hamper' pipeline: {str(e)}", exc_info=True)
+            # It's important to still try and uncheck the trigger to prevent re-triggering.
+            try:
+                uncheck_hamper_trigger(page_id)
+                logging.info(f"Unchecked hamper trigger for page {page_id} after error.")
+            except Exception as uncheck_e:
+                logging.error(f"Failed to uncheck hamper trigger for page {page_id} after error: {uncheck_e}", exc_info=True)
+
+            return {"success": False, "error": f"Critical pipeline error: {str(e)}"}
+
+hamper_pipeline_orchestrator = HamperPipelineOrchestrator()

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -492,9 +492,10 @@ def create_page_in_dirty_clothes_db(item_name: str, clothing_item_id: str, outfi
         logging.error(f"Failed to create page in Dirty Clothes database: {e}")
         raise
 
-def get_checked_todo_items_from_page(page_id: str) -> list:
+def get_checked_items_from_page(page_id: str) -> list:
     """
-    Retrieves all checked 'to_do' blocks from a page that mention a clothing item.
+    Retrieves all checked 'to_do' blocks from a page that mention a clothing item,
+    ignoring the "Send to Hamper" block.
     Returns a list of dicts, each containing the clothing item's page ID and name.
     """
     try:
@@ -503,13 +504,46 @@ def get_checked_todo_items_from_page(page_id: str) -> list:
         for block in blocks:
             if block.get("type") == "to_do" and block.get("to_do", {}).get("checked") is True:
                 rich_text = block.get("to_do", {}).get("rich_text", [])
+                # Ignore the "Send to Hamper" block
+                if any("Send to Hamper" in t.get("text", {}).get("content", "") for t in rich_text):
+                    continue
                 for text_item in rich_text:
                     if text_item.get("type") == "mention" and text_item.get("mention", {}).get("type") == "page":
                         clothing_item_id = text_item["mention"]["page"]["id"]
                         item_name = text_item["plain_text"]
                         checked_items.append({"id": clothing_item_id, "name": item_name})
-        logging.info(f"Found {len(checked_items)} checked to-do items on page {page_id}")
+        logging.info(f"Found {len(checked_items)} checked items on page {page_id}")
         return checked_items
     except Exception as e:
-        logging.error(f"Failed to get checked to-do items from page {page_id}: {e}")
+        logging.error(f"Failed to get checked items from page {page_id}: {e}")
         return []
+
+def add_items_to_dirty_clothes_db(items: list, outfit_log_id: str):
+    """
+    Adds a list of clothing items to the 'Dirty Clothes' database.
+    items: A list of dicts, each with "id" and "name" of the item.
+    """
+    for item in items:
+        try:
+            create_page_in_dirty_clothes_db(
+                item_name=item["name"],
+                clothing_item_id=item["id"],
+                outfit_log_id=outfit_log_id
+            )
+        except Exception as e:
+            logging.error(f"Failed to add item {item['id']} to dirty clothes DB: {e}")
+
+def uncheck_hamper_trigger(page_id: str):
+    """
+    Unchecks the 'Send to Hamper' checkbox on a given page.
+    """
+    try:
+        properties = {
+            "Send to Hamper": {
+                "checkbox": False
+            }
+        }
+        notion.pages.update(page_id=page_id, properties=properties)
+        logging.info(f"Unchecked 'Send to Hamper' for page {page_id}")
+    except Exception as e:
+        logging.error(f"Failed to uncheck 'Send to Hamper' for page {page_id}: {e}")

--- a/tests/test_hamper_pipeline.py
+++ b/tests/test_hamper_pipeline.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+from core.hamper_pipeline_orchestrator import HamperPipelineOrchestrator
+
+@pytest.fixture
+def mock_get_checked_items(mocker):
+    return mocker.patch('core.hamper_pipeline_orchestrator.get_checked_items_from_page', return_value=[{"id": "item1", "name": "T-shirt"}])
+
+@pytest.fixture
+def mock_add_to_db(mocker):
+    return mocker.patch('core.hamper_pipeline_orchestrator.add_items_to_dirty_clothes_db')
+
+@pytest.fixture
+def mock_uncheck_trigger(mocker):
+    return mocker.patch('core.hamper_pipeline_orchestrator.uncheck_hamper_trigger')
+
+@pytest.fixture
+def hamper_orchestrator():
+    return HamperPipelineOrchestrator()
+
+@pytest.mark.asyncio
+async def test_run_hamper_pipeline_success(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+    """
+    Tests that the hamper pipeline runs successfully.
+    """
+    page_id = "test_page_id"
+
+    result = await hamper_orchestrator.run_hamper_pipeline(page_id)
+
+    assert result["success"] is True
+    mock_get_checked_items.assert_called_once_with(page_id)
+    mock_add_to_db.assert_called_once_with([{"id": "item1", "name": "T-shirt"}], page_id)
+    mock_uncheck_trigger.assert_called_once_with(page_id)
+
+@pytest.mark.asyncio
+async def test_run_hamper_pipeline_no_items(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+    """
+    Tests that the hamper pipeline handles the case where there are no items to process.
+    """
+    page_id = "test_page_id"
+    mock_get_checked_items.return_value = []
+
+    result = await hamper_orchestrator.run_hamper_pipeline(page_id)
+
+    assert result["success"] is True
+    assert result["message"] == "No items to send to hamper."
+    mock_get_checked_items.assert_called_once_with(page_id)
+    mock_add_to_db.assert_not_called()
+    mock_uncheck_trigger.assert_called_once_with(page_id)
+
+@pytest.mark.asyncio
+async def test_run_hamper_pipeline_error(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+    """
+    Tests that the hamper pipeline handles errors gracefully.
+    """
+    page_id = "test_page_id"
+    mock_get_checked_items.side_effect = Exception("Test error")
+
+    result = await hamper_orchestrator.run_hamper_pipeline(page_id)
+
+    assert result["success"] is False
+    assert "Test error" in result["error"]
+    mock_get_checked_items.assert_called_once_with(page_id)
+    mock_add_to_db.assert_not_called()
+    mock_uncheck_trigger.assert_called_once_with(page_id)


### PR DESCRIPTION
This commit introduces the 'Send to Hamper' workflow, which allows users to send worn items to a 'Dirty Clothes' database in Notion.

Key changes:
- Added a new 'hamper' workflow to `services/webhook_server.py`, triggered by a 'Send to Hamper' checkbox.
- Created `core/hamper_pipeline_orchestrator.py` to manage the new workflow.
- Updated `data/notion_utils.py` with new functions to get checked items from a page, add items to the dirty clothes database, and uncheck the trigger.
- Added tests for the new hamper pipeline.