### PR TITLE
feat: Implement 'Laundry Day' workflow

### DIFF
--- a/core/laundry_day_pipeline_orchestrator.py
+++ b/core/laundry_day_pipeline_orchestrator.py
@@ -1,0 +1,42 @@
+import logging
+from data.notion_utils import (
+    get_related_wardrobe_item_id,
+    update_wardrobe_item_status,
+    delete_page
+)
+
+class LaundryDayPipelineOrchestrator:
+    """
+    Orchestrates the "Laundry Day" workflow.
+    """
+
+    def __init__(self):
+        pass
+
+    async def run_laundry_day_pipeline(self, page_id: str):
+        """
+        Main pipeline for the "Laundry Day" workflow.
+        """
+        try:
+            logging.info(f"🧺 Starting 'Laundry Day' pipeline for page {page_id}...")
+
+            # 1. Get the related wardrobe item ID
+            wardrobe_item_id = get_related_wardrobe_item_id(page_id)
+            if not wardrobe_item_id:
+                logging.error(f"Could not find related wardrobe item for page {page_id}")
+                return {"success": False, "error": "Could not find related wardrobe item."}
+
+            # 2. Update the wardrobe item's status to "Done"
+            update_wardrobe_item_status(wardrobe_item_id, "Done")
+
+            # 3. Delete the page from the "Dirty Clothes" database
+            delete_page(page_id)
+
+            logging.info(f"✅ 'Laundry Day' pipeline completed successfully for page {page_id}.")
+            return {"success": True}
+
+        except Exception as e:
+            logging.error(f"❌ Critical pipeline error in 'Laundry Day' pipeline: {str(e)}", exc_info=True)
+            return {"success": False, "error": f"Critical pipeline error: {str(e)}"}
+
+laundry_day_pipeline_orchestrator = LaundryDayPipelineOrchestrator()

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -418,7 +418,7 @@ def clear_trigger_fields(page_id):
         logging.error(f"Failed to clear trigger fields for page {page_id}: {e}")
         raise
 
-def update_items_washed_status(page_id: str, status: str = "Done"):
+def update_wardrobe_item_status(wardrobe_item_id: str, status: str):
     """
     Updates the 'Washed' status of a given clothing item page.
     """
@@ -430,22 +430,22 @@ def update_items_washed_status(page_id: str, status: str = "Done"):
                 }
             }
         }
-        notion.pages.update(page_id=page_id, properties=properties)
-        logging.info(f"Updated 'Washed' status to '{status}' for page {page_id}")
+        notion.pages.update(page_id=wardrobe_item_id, properties=properties)
+        logging.info(f"Updated 'Washed' status to '{status}' for page {wardrobe_item_id}")
     except Exception as e:
-        logging.error(f"Failed to update 'Washed' status for page {page_id}: {e}")
+        logging.error(f"Failed to update 'Washed' status for page {wardrobe_item_id}: {e}")
         raise
 
 
-def archive_page(page_id: str):
+def delete_page(page_id: str):
     """
-    Archives a given Notion page.
+    Deletes (archives) a given Notion page.
     """
     try:
         notion.pages.update(page_id=page_id, archived=True)
-        logging.info(f"Successfully archived page {page_id}")
+        logging.info(f"Successfully deleted (archived) page {page_id}")
     except Exception as e:
-        logging.error(f"Failed to archive page {page_id}: {e}")
+        logging.error(f"Failed to delete (archive) page {page_id}: {e}")
         raise
 
 def create_page_in_dirty_clothes_db(item_name: str, clothing_item_id: str, outfit_log_id: str):
@@ -547,3 +547,20 @@ def uncheck_hamper_trigger(page_id: str):
         logging.info(f"Unchecked 'Send to Hamper' for page {page_id}")
     except Exception as e:
         logging.error(f"Failed to uncheck 'Send to Hamper' for page {page_id}: {e}")
+
+def get_related_wardrobe_item_id(dirty_item_page_id: str) -> str:
+    """
+    Reads the relation property from a page in the 'Dirty Clothes' database
+    and returns the ID of the main wardrobe item.
+    """
+    try:
+        page = notion.pages.retrieve(page_id=dirty_item_page_id)
+        props = page.get("properties", {})
+        clothing_item_relation = props.get("Clothing Item", {}).get("relation", [])
+        if not clothing_item_relation:
+            logging.error(f"No clothing item relation found for page {dirty_item_page_id}")
+            return None
+        return clothing_item_relation[0]["id"]
+    except Exception as e:
+        logging.error(f"Failed to get related wardrobe item ID from page {dirty_item_page_id}: {e}")
+        return None

--- a/tests/test_laundry_day_pipeline.py
+++ b/tests/test_laundry_day_pipeline.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+from core.laundry_day_pipeline_orchestrator import LaundryDayPipelineOrchestrator
+
+@pytest.fixture
+def mock_get_related_item(mocker):
+    return mocker.patch('core.laundry_day_pipeline_orchestrator.get_related_wardrobe_item_id', return_value="wardrobe_item_id")
+
+@pytest.fixture
+def mock_update_status(mocker):
+    return mocker.patch('core.laundry_day_pipeline_orchestrator.update_wardrobe_item_status')
+
+@pytest.fixture
+def mock_delete_page(mocker):
+    return mocker.patch('core.laundry_day_pipeline_orchestrator.delete_page')
+
+@pytest.fixture
+def laundry_day_orchestrator():
+    return LaundryDayPipelineOrchestrator()
+
+@pytest.mark.asyncio
+async def test_run_laundry_day_pipeline_success(laundry_day_orchestrator, mock_get_related_item, mock_update_status, mock_delete_page):
+    """
+    Tests that the laundry day pipeline runs successfully.
+    """
+    page_id = "test_page_id"
+
+    result = await laundry_day_orchestrator.run_laundry_day_pipeline(page_id)
+
+    assert result["success"] is True
+    mock_get_related_item.assert_called_once_with(page_id)
+    mock_update_status.assert_called_once_with("wardrobe_item_id", "Done")
+    mock_delete_page.assert_called_once_with(page_id)
+
+@pytest.mark.asyncio
+async def test_run_laundry_day_pipeline_no_item(laundry_day_orchestrator, mock_get_related_item, mock_update_status, mock_delete_page):
+    """
+    Tests that the laundry day pipeline handles the case where there is no related item.
+    """
+    page_id = "test_page_id"
+    mock_get_related_item.return_value = None
+
+    result = await laundry_day_orchestrator.run_laundry_day_pipeline(page_id)
+
+    assert result["success"] is False
+    assert "Could not find related wardrobe item." in result["error"]
+    mock_get_related_item.assert_called_once_with(page_id)
+    mock_update_status.assert_not_called()
+    mock_delete_page.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_run_laundry_day_pipeline_error(laundry_day_orchestrator, mock_get_related_item, mock_update_status, mock_delete_page):
+    """
+    Tests that the laundry day pipeline handles errors gracefully.
+    """
+    page_id = "test_page_id"
+    mock_get_related_item.side_effect = Exception("Test error")
+
+    result = await laundry_day_orchestrator.run_laundry_day_pipeline(page_id)
+
+    assert result["success"] is False
+    assert "Test error" in result["error"]
+    mock_get_related_item.assert_called_once_with(page_id)
+    mock_update_status.assert_not_called()
+    mock_delete_page.assert_not_called()


### PR DESCRIPTION
This commit introduces the 'Laundry Day' workflow, which is triggered when a 'Washed' checkbox is checked in the 'Dirty Clothes' database.

Key changes:
- Updated the 'laundry_day' workflow trigger in `services/webhook_server.py`.
- Created `core/laundry_day_pipeline_orchestrator.py` to manage the new workflow.
- Updated `data/notion_utils.py` with new functions to get the related wardrobe item, update its status, and delete the page from the dirty clothes database.
- Refactored the `handle_laundry_day_workflow` to use the new orchestrator.
- Added tests for the new laundry day pipeline.