### PR TITLE
Fix import error in outfit pipeline orchestrator

### DIFF
--- a/core/outfit_pipeline_orchestrator.py
+++ b/core/outfit_pipeline_orchestrator.py
@@ -11,7 +11,7 @@ from data.notion_utils import (
     clear_page_content,
     clear_trigger_fields,
     OUTPUT_DB_ID,
-    get_checked_todo_items_from_page,
+    get_checked_items_from_page,
     create_page_in_dirty_clothes_db,
     update_items_washed_status
 )
@@ -31,7 +31,7 @@ class OutfitPipelineOrchestrator:
         """
         try:
             logging.info("🧺 Adding worn items to dirty clothes database...")
-            checked_items = get_checked_todo_items_from_page(page_id)
+            checked_items = get_checked_items_from_page(page_id)
             for item in checked_items:
                 # Add to dirty clothes DB
                 create_page_in_dirty_clothes_db(

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -356,45 +356,6 @@ def get_outfit_db_pages(output_db_id):
     except Exception as e:
         logging.error(f"Failed to get outfit DB pages: {e}")
         return []
-    
-def get_outfit_db_pages(output_db_id):
-    """
-    Get all pages from the outfit database with their properties.
-    Returns a list of page data including prompts and aesthetics.
-    """
-    try:
-        results = query_database(output_db_id)
-        pages = []
-
-        for result in results:
-            props = result.get("properties", {})
-
-            # Get Desired Aesthetic
-            aesthetic_prop = props.get("Desired Aesthetic", {})
-            multi_select = aesthetic_prop.get("multi_select", [])
-            aesthetics = [tag.get("name") for tag in multi_select]
-
-            # Get Prompt text
-            prompt_prop = props.get("Prompt", {})
-            rich_text = prompt_prop.get("rich_text", [])
-            prompt_text = "".join([t.get("plain_text", "") for t in rich_text]) if rich_text else ""
-
-            # Get Outfit Date
-            date_prop = props.get("Outfit Date", {})
-            outfit_date = date_prop.get("date", {}).get("start") if date_prop.get("date") else None
-
-            pages.append({
-                "id": result.get("id"),
-                "aesthetics": aesthetics,
-                "prompt": prompt_text,
-                "date": outfit_date,
-                "last_edited_time": result.get("last_edited_time")
-            })
-
-        return pages
-    except Exception as e:
-        logging.error(f"Failed to get outfit DB pages: {e}")
-        return []
 
 def clear_trigger_fields(page_id):
     """


### PR DESCRIPTION
- Renamed function `get_checked_todo_items_from_page` to `get_checked_items_from_page` in `core/outfit_pipeline_orchestrator.py` to match the function name in `data/notion_utils.py`. This resolves an `ImportError` that was preventing the outfit pipeline from loading.
- Removed a duplicated `get_outfit_db_pages` function from `data/notion_utils.py` to improve code quality.