### PR TITLE
Manage dirty clothes pipeline

### DIFF
--- a/core/hamper_pipeline_orchestrator.py
+++ b/core/hamper_pipeline_orchestrator.py
@@ -2,7 +2,8 @@ import logging
 from data.notion_utils import (
     get_checked_items_from_page,
     add_items_to_dirty_clothes_db,
-    uncheck_hamper_trigger
+    uncheck_hamper_trigger,
+    update_clothing_washed_status
 )
 
 class HamperPipelineOrchestrator:

--- a/tests/test_hamper_pipeline.py
+++ b/tests/test_hamper_pipeline.py
@@ -15,6 +15,10 @@ def mock_uncheck_trigger(mocker):
     return mocker.patch('core.hamper_pipeline_orchestrator.uncheck_hamper_trigger')
 
 @pytest.fixture
+def mock_update_washed_status(mocker):
+    return mocker.patch('core.hamper_pipeline_orchestrator.update_clothing_washed_status')
+
+@pytest.fixture
 def hamper_orchestrator():
     return HamperPipelineOrchestrator()
 
@@ -63,3 +67,41 @@ async def test_run_hamper_pipeline_error(hamper_orchestrator, mock_get_checked_i
     mock_get_checked_items.assert_called_once_with(page_id)
     mock_add_to_db.assert_not_called()
     mock_uncheck_trigger.assert_called_once_with(page_id)
+
+@pytest.mark.asyncio 
+async def test_dirty_clothes_workflow_integration():
+    """
+    Test the complete dirty clothes workflow integration.
+    """
+    with patch('data.notion_utils.remove_from_dirty_clothes_and_mark_washed') as mock_remove:
+        with patch('services.webhook_server.jsonify') as mock_jsonify:
+            mock_remove.return_value = True
+            mock_jsonify.return_value = ("mocked_response", 200)
+            
+            # Test the workflow handler
+            from services.webhook_server import handle_dirty_unchecked_workflow
+            
+            result = handle_dirty_unchecked_workflow("dirty_page_id")
+            
+            # Should return success response
+            assert result[1] == 200  # HTTP status code
+            mock_remove.assert_called_once_with("dirty_page_id")
+            mock_jsonify.assert_called()
+
+def test_washed_field_updates():
+    """
+    Test that washed field updates work correctly.
+    """
+    with patch('data.notion_utils.update_clothing_washed_status') as mock_update:
+        with patch('data.notion_utils.get_related_wardrobe_item_id') as mock_get_id:
+            with patch('data.notion_utils.delete_page') as mock_delete:
+                mock_get_id.return_value = "clothing_item_id"
+                
+                from data.notion_utils import remove_from_dirty_clothes_and_mark_washed
+                
+                result = remove_from_dirty_clothes_and_mark_washed("dirty_page_id")
+                
+                assert result is True
+                mock_get_id.assert_called_once_with("dirty_page_id")
+                mock_delete.assert_called_once_with("dirty_page_id")
+                mock_update.assert_called_once_with("clothing_item_id", "washed")


### PR DESCRIPTION
Implement the complete Dirty Clothes pipeline to manage clothing item status from dirty to washed.

This PR addresses several gaps in the existing pipeline, including setting the 'Washed' status to 'not started' when items are sent to the hamper, correcting the 'Dirty' property name, and adding a webhook handler to remove items from the Dirty Clothes database and mark them as 'washed' when the 'Dirty' checkbox is unchecked.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0c19a31-0a1a-496f-bfc3-6c38a843b174">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0c19a31-0a1a-496f-bfc3-6c38a843b174">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

