### PR TITLE
Debug dirty clothes pipeline not triggering

### DIFF
--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -284,7 +284,16 @@ def determine_workflow_type(page_id):
         logging.info(f"Checking against Outfit Log DB ID: {outfit_log_db_id}")
         hamper_prop = props.get("Send to Hamper", {})
         if parent_db_id and parent_db_id == outfit_log_db_id:
-            if hamper_prop.get("type") == "checkbox" and hamper_prop.get("checkbox"):
+            prop_checked = (hamper_prop.get("type") == "checkbox" and hamper_prop.get("checkbox"))
+            # Fallback to detecting a checked to-do block named 'Send to Hamper'
+            has_checked_block = False
+            try:
+                from data.notion_utils import has_checked_hamper_todo_block
+                has_checked_block = has_checked_hamper_todo_block(page_id)
+            except Exception as e:
+                logging.error(f"Error checking hamper to-do block: {e}")
+            logging.info(f"Hamper property checked={prop_checked}, hamper to-do checked={has_checked_block}")
+            if prop_checked or has_checked_block:
                 logging.info("🧺 Hamper trigger detected.")
                 return "hamper"
 


### PR DESCRIPTION
Add fallback trigger for Dirty Clothes pipeline to detect 'Send to Hamper' to-do block, improving robustness when the page property is not used.

The pipeline was not triggering for the user, indicating the existing page property check was insufficient. This change ensures the workflow activates even if the user relies on a to-do block for the trigger, and also cleans up both trigger types after processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-c17a266a-a8c4-4f4d-956e-f3810c47dd82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c17a266a-a8c4-4f4d-956e-f3810c47dd82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

