### PR TITLE
The health check endpoint was calling `get_stats()` on the `SmartCach…

### DIFF
--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -915,7 +915,7 @@ if FLASK_AVAILABLE:
             if advanced_cache:
                 try:
                     import asyncio
-                    cache_stats = asyncio.run(advanced_cache.get_stats())
+                    cache_stats = asyncio.run(advanced_cache.get_comprehensive_stats())
                     health_data["cache"] = cache_stats
                 except Exception as e:
                     health_data["cache_error"] = str(e)


### PR DESCRIPTION
…eManager` object, which does not exist. This caused an `AttributeError` and a `cache_error` in the health check response.

This commit fixes the issue by changing the method call to `get_comprehensive_stats()`, which is the correct method for retrieving cache statistics.