### PR TITLE
fix: Prevent logging of environment variables

### DIFF
--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -60,9 +60,6 @@ def check_environment_variables():
         return False
     
     logging.info("✅ All environment variables present")
-    for var, value in required_vars.items():
-        masked_value = value[:8] + "..." if len(value) > 8 else "***"
-        logging.info(f"   {var}: {masked_value}")
     
     return True
 


### PR DESCRIPTION
Removes the logging of environment variables in the `check_environment_variables` function to prevent leaking secrets in the logs.