### PR TITLE
feat: Add color tag filtering to outfit generation

### DIFF
--- a/core/outfit_logic.py
+++ b/core/outfit_logic.py
@@ -193,7 +193,7 @@ def pick_footwear(items, desired_aesthetic, base_colors):
     return pick_one(candidates)
 
 
-def build_outfit(items, hot, desired_aesthetic, washed_required="Done"):
+def build_outfit(items, hot, desired_aesthetic, desired_color=None, washed_required="Done"):
     """
     Builds a complete, color-coordinated outfit from available items.
     Now uses individual weather tags while maintaining function signature.
@@ -214,13 +214,20 @@ def build_outfit(items, hot, desired_aesthetic, washed_required="Done"):
         logging.warning(f"No items found suitable for {'hot' if hot else 'cold'} weather.")
         return []
 
-    # 2. Pick an upper body item to set the base color scheme
-    upper = pick_upper_body(weather_filtered_items, desired_aesthetic, base_colors=[])
+    # 2. Determine base colors and pick upper body
+    base_colors = []
+    if desired_color:
+        base_colors = [desired_color]
+        upper = pick_upper_body(weather_filtered_items, desired_aesthetic, base_colors=base_colors)
+    else:
+        # Pick an upper body item to set the base color scheme
+        upper = pick_upper_body(weather_filtered_items, desired_aesthetic, base_colors=[])
+        if upper:
+            base_colors = upper.get("color", [])
+
     if not upper:
         logging.warning("No upper body garment found for outfit.")
         return []
-
-    base_colors = upper.get("color", [])
 
     # 3. Pick other items that are compatible with the upper body item (all use fallback logic)
     lower = pick_lower_body(weather_filtered_items, hot, desired_aesthetic, base_colors)

--- a/core/outfit_pipeline_orchestrator.py
+++ b/core/outfit_pipeline_orchestrator.py
@@ -6,6 +6,7 @@ from data.weather_utils import get_weather_forecast
 from core.outfit_planner_agent import outfit_planner_agent
 from data.notion_utils import (
     get_selected_aesthetic_from_output_db,
+    get_selected_color_from_output_db,
     get_output_page_id,
     post_outfit_to_notion_page,
     clear_page_content,
@@ -52,23 +53,24 @@ class OutfitPipelineOrchestrator:
         try:
             logging.info("👕 Starting daily outfit pipeline...")
 
-            # 1. Get wardrobe data
-            wardrobe_items = wardrobe_data_manager.get_all_wardrobe_items()
-            if not wardrobe_items:
-                return {"success": False, "error": "No wardrobe items available."}
+            # 1. Get user preferences from Notion
+            selected_aesthetics = get_selected_aesthetic_from_output_db(OUTPUT_DB_ID)
+            desired_aesthetic = selected_aesthetics[0] if selected_aesthetics else "Minimalist"
+            desired_color = get_selected_color_from_output_db(OUTPUT_DB_ID)
 
             # 2. Get weather forecast
             forecast = get_weather_forecast()
             weather_tag = forecast["weather_tag"]
 
-            # 3. Get user preferences
-            selected_aesthetics = get_selected_aesthetic_from_output_db(OUTPUT_DB_ID)
-            desired_aesthetic = selected_aesthetics[0] if selected_aesthetics else "Minimalist"
+            # 3. Get LLM-optimized context from data manager
+            context = wardrobe_data_manager.get_llm_optimized_context(
+                aesthetic=desired_aesthetic,
+                weather_tag=weather_tag,
+                color_tag=desired_color
+            )
 
             # 4. Generate outfit
-            result = await outfit_planner_agent.generate_outfit(
-                wardrobe_items, weather_tag, desired_aesthetic
-            )
+            result = await outfit_planner_agent.generate_outfit(context)
 
             if not result["success"]:
                 return result

--- a/core/outfit_planner_agent.py
+++ b/core/outfit_planner_agent.py
@@ -21,18 +21,10 @@ class OutfitPlannerAgent:
         self._api_retry_attempts = api_retry_attempts
         self._api_retry_delay = api_retry_delay
 
-    async def generate_outfit(
-        self, wardrobe_items: List[Dict], weather_tag: str, desired_aesthetic: str
-    ) -> Dict:
+    async def generate_outfit(self, context: Dict) -> Dict:
         """
         Generates an outfit using the hierarchical fallback chain.
         """
-        context = {
-            "available_items": self._categorize_items(wardrobe_items),
-            "weather_condition": weather_tag,
-            "desired_aesthetic": desired_aesthetic,
-        }
-
         # 1. Try Gemini
         success, outfit, error_msg = await outfit_llm_agents.generate_outfit_with_gemini(context)
         if success and outfit:
@@ -47,7 +39,17 @@ class OutfitPlannerAgent:
 
         # 3. Fallback to rule-based logic
         logging.info("Falling back to rule-based outfit generation.")
-        outfit = build_outfit(wardrobe_items, weather_tag == "hot", desired_aesthetic)
+        wardrobe_items = [
+            item
+            for category in context["available_items"].values()
+            for item in category
+        ]
+        outfit = build_outfit(
+            wardrobe_items,
+            context["weather_condition"] == "hot",
+            context["desired_aesthetic"],
+            context["desired_color"],
+        )
         if outfit:
             return {"success": True, "outfit": outfit, "generation_method": "rule_based_fallback"}
 

--- a/data/data_manager.py
+++ b/data/data_manager.py
@@ -84,6 +84,7 @@ class WardrobeDataManager:
     def get_filtered_wardrobe_items(self,
                                    aesthetic: str = None,
                                    weather_tag: str = None,
+                                   color_tag: str = None,
                                    categories: List[str] = None,
                                    washed_only: bool = True) -> List[Dict]:
         """
@@ -93,6 +94,7 @@ class WardrobeDataManager:
         Args:
             aesthetic: Filter by aesthetic (e.g., "Minimalist", "Casual")
             weather_tag: Filter by weather ("Hot", "Cold")
+            color_tag: Filter by color
             categories: List of categories to include
             washed_only: Only include washed items
             
@@ -106,6 +108,7 @@ class WardrobeDataManager:
                 items = supabase_client.get_filtered_wardrobe_items(
                     aesthetic=aesthetic,
                     weather_tag=weather_tag,
+                    color_tag=color_tag,
                     categories=categories,
                     washed_only=washed_only
                 )
@@ -119,7 +122,7 @@ class WardrobeDataManager:
         try:
             all_items = self.get_all_wardrobe_items()  # This will use the hierarchy
             filtered_items = self._apply_local_filters(
-                all_items, aesthetic, weather_tag, categories, washed_only
+                all_items, aesthetic, weather_tag, color_tag, categories, washed_only
             )
             logging.info(f"Applied local filtering: {len(filtered_items)} items match criteria")
             return filtered_items
@@ -127,7 +130,7 @@ class WardrobeDataManager:
             logging.error(f"Local filtering failed: {e}")
             raise Exception("Unable to retrieve filtered wardrobe data")
     
-    def get_llm_optimized_context(self, aesthetic: str, weather_tag: str) -> Dict:
+    def get_llm_optimized_context(self, aesthetic: str, weather_tag: str, color_tag: str = None) -> Dict:
         """
         Get wardrobe data organized by category for optimal LLM consumption.
         Minimizes tokens while providing complete context.
@@ -135,6 +138,7 @@ class WardrobeDataManager:
         Args:
             aesthetic: Desired aesthetic style
             weather_tag: Weather condition ("Hot" or "Cold")
+            color_tag: Desired color
             
         Returns:
             Dictionary organized by clothing categories
@@ -143,25 +147,30 @@ class WardrobeDataManager:
             context = {
                 "weather_condition": weather_tag,
                 "desired_aesthetic": aesthetic,
+                "desired_color": color_tag,
                 "available_items": {
                     "tops": self.get_filtered_wardrobe_items(
                         aesthetic=aesthetic,
                         weather_tag=weather_tag,
+                        color_tag=color_tag,
                         categories=["Polo", "T-shirt", "Sport T-shirt", "Shirt"]
                     ),
                     "bottoms": self.get_filtered_wardrobe_items(
                         aesthetic=aesthetic,
                         weather_tag=weather_tag,
+                        color_tag=color_tag,
                         categories=["Cargo Pants", "Chinos", "Jeans", "Joggers", "Pants", "Shorts"]
                     ),
                     "outerwear": self.get_filtered_wardrobe_items(
                         aesthetic=aesthetic,
                         weather_tag=weather_tag,
+                        color_tag=color_tag,
                         categories=["Crewneck", "Hoodie", "Fleece", "Jacket", "Overcoat", "Overshirt", "Suit"]
                     ),
                     "footwear": self.get_filtered_wardrobe_items(
                         aesthetic=aesthetic,
                         weather_tag=weather_tag,
+                        color_tag=color_tag,
                         categories=["Shoes", "Sneakers"]
                     )
                 }
@@ -240,7 +249,7 @@ class WardrobeDataManager:
         return get_wardrobe_items(self.wardrobe_db_id)
     
     def _apply_local_filters(self, items: List[Dict], aesthetic: str, weather_tag: str, 
-                           categories: List[str], washed_only: bool) -> List[Dict]:
+                           color_tag: str, categories: List[str], washed_only: bool) -> List[Dict]:
         """Apply filtering logic locally (fallback when Supabase filtering fails)"""
         filtered = []
         
@@ -269,6 +278,12 @@ class WardrobeDataManager:
             # Category filter
             if categories and item.get('category') not in categories:
                 continue
+
+            # Color filter
+            if color_tag:
+                item_colors = [c.lower() for c in item.get('color', [])]
+                if color_tag.lower() not in item_colors:
+                    continue
             
             filtered.append(item)
         

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -279,6 +279,29 @@ def get_selected_aesthetic_from_output_db(output_db_id):
         logging.error(f"Failed to get selected aesthetic from output DB {output_db_id}: {e}")
         return []
 
+
+def get_selected_color_from_output_db(output_db_id):
+    """
+    Query the output database and return the selected color.
+    Returns the first selected color string or None.
+    """
+    try:
+        results = query_database(output_db_id)
+        if not results:
+            logging.warning("Output database has no pages.")
+            return None
+        page = results[0]
+        props = page.get("properties", {})
+        color_prop = props.get("Desired Color", {})
+        multi_select = color_prop.get("multi_select", [])
+        if multi_select:
+            return multi_select[0].get("name")
+        return None
+    except Exception as e:
+        logging.error(f"Failed to get selected color from output DB {output_db_id}: {e}")
+        return None
+
+
 def get_output_page_id(output_db_id):
     """
     Query output database for the single page ID inside.


### PR DESCRIPTION
This commit introduces the ability to filter outfits by a desired color. The changes propagate the `color_tag` from Notion all the way down to the data fetching layer.

- A new function `get_selected_color_from_output_db` is added to `data/notion_utils.py` to fetch the desired color from Notion.
- `data/data_manager.py` is updated to accept a `color_tag` and use it to filter wardrobe items from Supabase or locally.
- `core/outfit_pipeline_orchestrator.py` is updated to fetch the desired color and pass it to the data manager to get a color-filtered context for the LLM.
- `core/outfit_planner_agent.py` is updated to pass the `desired_color` to the rule-based fallback `build_outfit` function.
- `core/outfit_logic.py`'s `build_outfit` function is updated to use the `desired_color` to simplify its logic when a color is specified.