### PR TITLE
Fix infinite loop in travel pipeline

### DIFF
--- a/core/notion_result_publisher.py
+++ b/core/notion_result_publisher.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from typing import Dict, List
 
-from data.notion_utils import notion, clear_page_content
+from data.notion_utils import notion, clear_page_content, update_notion_page_status
 from data.data_manager import wardrobe_data_manager
 from core.outfit_planner_agent import outfit_planner_agent
 
@@ -23,10 +23,7 @@ class NotionResultPublisher:
         Finalizes the packing results by updating Notion.
         """
         try:
-            logging.info(f"🧳 Finalizing packing results using {generation_method}...")
-
-            # Immediately clear trigger fields to prevent re-triggering
-            await asyncio.to_thread(self._clear_travel_trigger_fields_safe, page_id)
+            logging.info(f"🧳 Finalizing packing results for page {page_id} using {generation_method}...")
 
             self._log_packing_summary(packing_result)
 
@@ -41,11 +38,16 @@ class NotionResultPublisher:
             )
             await self._generate_and_post_example_outfits(page_id, packing_result, trip_config)
 
+            # Set status to "Complete" after successfully posting all content
+            await asyncio.to_thread(update_notion_page_status, page_id, "Complete")
+
             logging.info("✅ Finalization completed successfully")
             return {"success": True}
 
         except Exception as e:
             logging.error(f"❌ Error in results finalization: {e}", exc_info=True)
+            # Set status to "Error" on failure
+            await asyncio.to_thread(update_notion_page_status, page_id, "Error")
             return {
                 "success": False,
                 "error": f"Failed to finalize outfit: {str(e)}",
@@ -284,26 +286,6 @@ class NotionResultPublisher:
                     "bulleted_list_item": {"rich_text": [{"type": "text", "text": {"content": line.replace("*","").strip()}}]}
                 })
         return blocks
-
-    def _clear_travel_trigger_fields_safe(self, page_id: str) -> None:
-        """Safely clear travel trigger fields."""
-        try:
-            logging.info(f"🧳 Safely clearing travel trigger fields for page {page_id}")
-            page = notion.pages.retrieve(page_id=page_id)
-            properties = page.get("properties", {})
-            update_properties = {}
-            trigger_fields = {
-                "Generate": {"checkbox": False},
-                "Generate Travel Packing": {"checkbox": False},
-            }
-            for field_name, field_value in trigger_fields.items():
-                if field_name in properties:
-                    update_properties[field_name] = field_value
-            if update_properties:
-                notion.pages.update(page_id=page_id, properties=update_properties)
-                logging.info(f"✅ Cleared {len(update_properties)} trigger fields")
-        except Exception as e:
-            logging.warning(f"⚠️  Could not clear trigger fields (non-critical): {e}")
 
     def _create_rich_text(self, content: str, bold: bool = False) -> List[Dict]:
         """Helper to create properly formatted rich text for Notion API."""

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -680,6 +680,26 @@ def find_and_uncheck_hamper_todo_block(page_id: str) -> None:
                 logging.error(f"Error unchecking 'Send to Hamper' to-do block {block_id} on page {page_id}: {e}")
                 return
 
+def update_notion_page_status(page_id: str, status: str):
+    """
+    Updates the 'Status' property of a Notion page.
+    Assumes the property is a 'select' type.
+    """
+    try:
+        # Check if the "Status" property exists before attempting to update
+        page = notion.pages.retrieve(page_id=page_id)
+        if "Status" not in page.get("properties", {}):
+            logging.warning(f"Page {page_id} does not have a 'Status' property. Skipping update.")
+            return
+
+        properties = {"Status": {"select": {"name": status}}}
+        notion.pages.update(page_id=page_id, properties=properties)
+        logging.info(f"✅ Updated status to '{status}' for page {page_id}")
+    except Exception as e:
+        # Log with traceback for better debugging
+        logging.error(f"❌ Failed to update status for page {page_id}: {e}", exc_info=True)
+
+
 def remove_from_dirty_clothes_and_mark_washed(dirty_item_page_id: str):
     """
     Removes an item from the Dirty Clothes database and marks the original clothing item as 'washed'.

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -236,6 +236,14 @@ def determine_workflow_type(page_id):
         parent_db_id = page.get("parent", {}).get("database_id", "").replace("-", "")
         logging.info(f"Checking parent DB ID: {parent_db_id}")
 
+        # Check for a "Status" property to prevent re-triggering completed workflows
+        status_prop = props.get("Status", {}).get("select", {})
+        current_status = status_prop.get("name") if status_prop else None
+
+        if current_status in ["In Progress", "Complete"]:
+            logging.info(f"Workflow for page {page_id} is already '{current_status}'. Skipping.")
+            return None
+
         # Dirty Clothes database workflows
         dirty_clothes_db_id = os.getenv("NOTION_DIRTY_CLOTHES_DB_ID", "").replace("-", "")
         if parent_db_id and parent_db_id == dirty_clothes_db_id:
@@ -255,8 +263,6 @@ def determine_workflow_type(page_id):
         for name in ["Generate", "Generate Travel Packing", "Generate Packing", "Travel Generate"]:
             if name in props and props[name].get("type") == "checkbox" and props[name].get("checkbox"):
                 logging.info(f"🧳 Travel override checkbox '{name}' detected.")
-                # Clear the checkbox immediately to prevent re-triggering
-                clear_travel_trigger_checkbox(page_id, name)
                 return "travel"
 
         # Travel auto-trigger
@@ -356,56 +362,15 @@ def handle_outfit_workflow(page_id):
         logging.error(f"❌ Outfit workflow error: {e}", exc_info=True)
         return jsonify({"error": "Outfit workflow failed"}), 500
 
-# In-memory processing state tracking
-_processing_pages = set()
-
-def check_processing_state(page_id):
-    """Check if the page is currently being processed to prevent infinite loops."""
-    return page_id in _processing_pages
-
-def set_processing_state(page_id, processing=True):
-    """Set the processing state to prevent concurrent runs."""
-    try:
-        if processing:
-            _processing_pages.add(page_id)
-            logging.info(f"✅ Set processing state to True for page {page_id}")
-        else:
-            _processing_pages.discard(page_id)  # discard won't error if not present
-            logging.info(f"✅ Set processing state to False for page {page_id}")
-    except Exception as e:
-        logging.warning(f"Could not set processing state: {e}")
-
-def clear_travel_trigger_checkbox(page_id, checkbox_name):
-    """Clear a specific travel trigger checkbox to prevent re-triggering."""
-    try:
-        notion = _get_notion_client()
-        if not notion:
-            return
-        
-        notion.pages.update(
-            page_id=page_id,
-            properties={checkbox_name: {"checkbox": False}}
-        )
-        logging.info(f"✅ Cleared trigger checkbox '{checkbox_name}' for page {page_id}")
-    except Exception as e:
-        logging.warning(f"Could not clear trigger checkbox: {e}")
 
 def handle_travel_workflow(page_id):
     """Handle travel packing workflow with infinite loop prevention"""
     try:
+        from data.notion_utils import update_notion_page_status
         logging.info(f"🧳 ENTERING handle_travel_workflow for page {page_id}")
         
-        # Check if already processing
-        if check_processing_state(page_id):
-            logging.warning(f"⚠️  Page {page_id} is already being processed. Skipping to prevent infinite loop.")
-            return jsonify({
-                "message": "Travel packing already in progress", 
-                "page_id": page_id,
-                "status": "already_processing"
-            }), 200
-        
-        # Set processing state immediately
-        set_processing_state(page_id, True)
+        # Set status to "In Progress" to lock the page from re-triggering
+        update_notion_page_status(page_id, "In Progress")
         
         # Extract travel trigger data with debugging
         logging.info(f"🧳 About to call get_travel_trigger_data")
@@ -413,7 +378,7 @@ def handle_travel_workflow(page_id):
         
         if not travel_trigger_data:
             logging.error("❌ Failed to extract travel trigger data")
-            set_processing_state(page_id, False)  # Clear processing state on error
+            update_notion_page_status(page_id, "Error")
             return jsonify({"error": "Failed to extract travel trigger data"}), 400
         
         logging.info(f"✅ Travel trigger data extracted: {travel_trigger_data}")
@@ -423,7 +388,7 @@ def handle_travel_workflow(page_id):
         travel_orchestrator = core_functions.get('travel_pipeline_orchestrator')
         
         if not travel_orchestrator:
-            set_processing_state(page_id, False)  # Clear processing state on error
+            update_notion_page_status(page_id, "Error")
             return jsonify({"error": "Travel pipeline not available"}), 500
         
         # Test orchestrator access
@@ -433,7 +398,7 @@ def handle_travel_workflow(page_id):
             logging.info(f"🧳 Orchestrator has run_travel_packing_pipeline method: {test_result}")
         except Exception as e:
             logging.error(f"❌ Orchestrator access test failed: {e}")
-            set_processing_state(page_id, False)  # Clear processing state on error
+            update_notion_page_status(page_id, "Error")
             return jsonify({"error": f"Orchestrator access failed: {str(e)}"}), 500
         
         logging.info(f"🧳 Starting async travel pipeline...")
@@ -455,7 +420,7 @@ def handle_travel_workflow(page_id):
         
     except Exception as e:
         logging.error(f"❌ Travel workflow error: {e}", exc_info=True)
-        set_processing_state(page_id, False)  # Clear processing state on error
+        update_notion_page_status(page_id, "Error")
         return jsonify({
             "error": "Travel workflow failed", 
             "details": str(e),
@@ -684,18 +649,17 @@ def run_async_travel_pipeline(travel_orchestrator, trigger_data):
             # No event loop running, safe to use asyncio.run
             result = asyncio.run(travel_orchestrator.run_travel_packing_pipeline(trigger_data))
         
-        # Clear processing state after completion
-        if page_id:
-            set_processing_state(page_id, False)
-            logging.info(f"✅ Travel pipeline completed for page {page_id}")
+        # The orchestrator is now responsible for setting the final status
+        logging.info(f"✅ Async travel pipeline function finished for page {page_id}")
         
         return result
     
     except Exception as e:
         logging.error(f"Error in async travel pipeline: {e}", exc_info=True)
-        # Clear processing state on error
+        # Set status to "Error" on failure
         if page_id:
-            set_processing_state(page_id, False)
+            from data.notion_utils import update_notion_page_status
+            update_notion_page_status(page_id, "Error")
         return {"success": False, "error": str(e)}
 
 

--- a/tests/test_notion_result_publisher.py
+++ b/tests/test_notion_result_publisher.py
@@ -45,11 +45,25 @@ async def test_finalize_packing_results_failure(notion_publisher, mocker):
     }
     trip_config = {}
 
-    with patch('core.notion_result_publisher.asyncio.to_thread', new_callable=AsyncMock) as mock_to_thread:
-        mock_to_thread.side_effect = Exception("Notion API failed")
-        result = await notion_publisher.finalize_packing_results(
-            page_id, packing_result, "gemini", trip_config
-        )
+    # Mock the specific function that is expected to fail
+    mocker.patch(
+        'core.notion_result_publisher.NotionResultPublisher._update_trip_worthy_selections',
+        new_callable=AsyncMock,
+        side_effect=Exception("Notion API failed")
+    )
 
-        assert result["success"] is False
-        assert "Failed to finalize outfit" in result["error"]
+    # Mock the status update function to verify it's called correctly
+    mock_update_status = mocker.patch(
+        'core.notion_result_publisher.update_notion_page_status',
+        new_callable=MagicMock
+    )
+
+    result = await notion_publisher.finalize_packing_results(
+        page_id, packing_result, "gemini", trip_config
+    )
+
+    assert result["success"] is False
+    assert "Failed to finalize outfit" in result["error"]
+
+    # Verify that the status was updated to "Error"
+    mock_update_status.assert_called_once_with(page_id, "Error")


### PR DESCRIPTION
The travel agent pipeline was getting into an infinite loop when posting the packing guide to Notion. This was because the update to the Notion page would re-trigger the webhook, and the in-memory mechanism for preventing this was not robust enough for a serverless environment.

This change replaces the in-memory state management with a 'Status' property on the Notion page itself. The status is set to 'In Progress' when the pipeline starts, and 'Complete' or 'Error' when it finishes. The webhook trigger is modified to check this status, preventing the pipeline from running again on a page that has already been processed.

This new mechanism is more robust and solves the infinite loop issue.