### PR TITLE
feat: Update "Washed" status values in Notion

### DIFF
--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -96,7 +96,7 @@ def get_wardrobe_items(wardrobe_db_id):
         brand_name = brand_select.get("name") if brand_select else None
 
         washed_select = props.get("Washed", {}).get("select", {})
-        washed_value = washed_select.get("name") if washed_select else "Not Done"
+        washed_value = washed_select.get("name") if washed_select else "Not started"
 
         color_multi = props.get("Color", {}).get("multi_select", [])
         color_names = [c.get("name") for c in color_multi]
@@ -528,7 +528,7 @@ def create_page_in_dirty_clothes_db(item_name: str, clothing_item_id: str, outfi
         logging.info(f"Added '{item_name}' to Dirty Clothes database.")
         
         # Update the original clothing item's washed status to "not started"
-        update_clothing_washed_status(clothing_item_id, "not started")
+        update_clothing_washed_status(clothing_item_id, "Not started")
         
     except Exception as e:
         logging.error(f"Failed to create page in Dirty Clothes database: {e}")
@@ -719,7 +719,7 @@ def remove_from_dirty_clothes_and_mark_washed(dirty_item_page_id: str):
         logging.info(f"Removed page {dirty_item_page_id} from Dirty Clothes database")
         
         # Update the original clothing item's washed status to "Done"
-        update_clothing_washed_status(clothing_item_id, "washed")
+        update_clothing_washed_status(clothing_item_id, "Done")
         logging.info(f"Marked clothing item {clothing_item_id} as washed")
         
         return True

--- a/tests/test_hamper_pipeline.py
+++ b/tests/test_hamper_pipeline.py
@@ -105,7 +105,7 @@ def test_washed_field_updates():
                 assert result is True
                 mock_get_id.assert_called_once_with("dirty_page_id")
                 mock_delete.assert_called_once_with("dirty_page_id")
-                mock_update.assert_called_once_with("clothing_item_id", "washed")
+                mock_update.assert_called_once_with("clothing_item_id", "Done")
 
 def test_wardrobe_item_validation():
     """


### PR DESCRIPTION
This commit updates the "Washed" field status in the Notion database to use "Done" instead of "washed" and "Not started" instead of "not started".

The following changes were made:
- In `data/notion_utils.py`:
  - `remove_from_dirty_clothes_and_mark_washed` now sets the status to "Done".
  - `create_page_in_dirty_clothes_db` now sets the status to "Not started".
  - `get_wardrobe_items` now defaults the `washed` status to "Not started".
- In `tests/test_hamper_pipeline.py`:
  - The test `test_washed_field_updates` was updated to expect "Done" instead of "washed".