### PR TITLE
fix(webhook): Prevent crash when creating travel response

### DIFF
--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -410,7 +410,7 @@ def handle_travel_workflow(page_id):
             "workflow": "travel",
             "status": "processing",
             "trip_type": "business_school_relocation",
-            "destinations": [d.get("city", "Unknown") for d in travel_trigger_data.get("destinations", [])],
+            "destinations": travel_trigger_data.get("destinations", []),
             "debug_info": {
                 "trigger_data_extracted": True,
                 "orchestrator_accessible": True,


### PR DESCRIPTION
In the `handle_travel_workflow` function, the code for generating the JSON response attempted to treat a list of destination strings as a list of dictionaries. This caused an `AttributeError: 'str' object has no attribute 'get'` when the `destinations` property was populated.

The `_read_destinations` function always returns a list of strings, so the fix is to use this list directly in the response rather than attempting to process it.