### PR TITLE
Fix: Prevent infinite loop in travel packing pipeline

### DIFF
--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -680,24 +680,26 @@ def find_and_uncheck_hamper_todo_block(page_id: str) -> None:
                 logging.error(f"Error unchecking 'Send to Hamper' to-do block {block_id} on page {page_id}: {e}")
                 return
 
-def update_notion_page_status(page_id: str, status: str):
+def update_notion_page_status(page_id: str, status: str) -> bool:
     """
     Updates the 'Status' property of a Notion page.
-    Assumes the property is a 'select' type.
+    Returns True on success, False on failure.
     """
     try:
         # Check if the "Status" property exists before attempting to update
         page = notion.pages.retrieve(page_id=page_id)
         if "Status" not in page.get("properties", {}):
-            logging.warning(f"Page {page_id} does not have a 'Status' property. Skipping update.")
-            return
+            logging.error(f"Page {page_id} does not have a 'Status' property. Cannot update status.")
+            return False
 
         properties = {"Status": {"select": {"name": status}}}
         notion.pages.update(page_id=page_id, properties=properties)
         logging.info(f"✅ Updated status to '{status}' for page {page_id}")
+        return True
     except Exception as e:
         # Log with traceback for better debugging
         logging.error(f"❌ Failed to update status for page {page_id}: {e}", exc_info=True)
+        return False
 
 
 def remove_from_dirty_clothes_and_mark_washed(dirty_item_page_id: str):

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -370,7 +370,9 @@ def handle_travel_workflow(page_id):
         logging.info(f"🧳 ENTERING handle_travel_workflow for page {page_id}")
         
         # Set status to "In Progress" to lock the page from re-triggering
-        update_notion_page_status(page_id, "In Progress")
+        if not update_notion_page_status(page_id, "In Progress"):
+            logging.error(f"CRITICAL: Failed to set 'In Progress' status for page {page_id}. Aborting.")
+            return jsonify({"error": "Failed to set 'In Progress' status, aborting to prevent loop."}), 500
         
         # Extract travel trigger data with debugging
         logging.info(f"🧳 About to call get_travel_trigger_data")
@@ -420,7 +422,7 @@ def handle_travel_workflow(page_id):
         
     except Exception as e:
         logging.error(f"❌ Travel workflow error: {e}", exc_info=True)
-        update_notion_page_status(page_id, "Error")
+        # No need to update status here, as it might be the cause of the error
         return jsonify({
             "error": "Travel workflow failed", 
             "details": str(e),


### PR DESCRIPTION
The travel packing pipeline was entering an infinite loop if the Notion page that triggered the workflow was missing a 'Status' property. This was because the function to update the status was failing silently, preventing the status-locking mechanism from working. Subsequent updates to the page by the result publisher would then re-trigger the workflow.

This commit fixes the issue by:
1.  Modifying `update_notion_page_status` to return a boolean value indicating success or failure, instead of failing silently.
2.  Updating `handle_travel_workflow` to check this return value. If the status cannot be set to 'In Progress', the workflow is now aborted with an error, preventing the infinite loop.