### PR TITLE
feat: Use 'Generate' checkbox for travel pipeline trigger

### DIFF
--- a/core/notion_result_publisher.py
+++ b/core/notion_result_publisher.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from typing import Dict, List
 
-from data.notion_utils import notion, clear_page_content, update_notion_page_status
+from data.notion_utils import notion, clear_page_content, update_page_checkbox
 from data.data_manager import wardrobe_data_manager
 from core.outfit_planner_agent import outfit_planner_agent
 
@@ -38,16 +38,16 @@ class NotionResultPublisher:
             )
             await self._generate_and_post_example_outfits(page_id, packing_result, trip_config)
 
-            # Set status to "Complete" after successfully posting all content
-            await asyncio.to_thread(update_notion_page_status, page_id, "Complete")
+            # Uncheck the "Generate" checkbox to indicate completion
+            await asyncio.to_thread(update_page_checkbox, page_id, "Generate", False)
 
             logging.info("✅ Finalization completed successfully")
             return {"success": True}
 
         except Exception as e:
             logging.error(f"❌ Error in results finalization: {e}", exc_info=True)
-            # Set status to "Error" on failure
-            await asyncio.to_thread(update_notion_page_status, page_id, "Error")
+            # Uncheck the "Generate" checkbox even on failure to prevent re-triggering
+            await asyncio.to_thread(update_page_checkbox, page_id, "Generate", False)
             return {
                 "success": False,
                 "error": f"Failed to finalize outfit: {str(e)}",

--- a/data/notion_utils.py
+++ b/data/notion_utils.py
@@ -680,25 +680,19 @@ def find_and_uncheck_hamper_todo_block(page_id: str) -> None:
                 logging.error(f"Error unchecking 'Send to Hamper' to-do block {block_id} on page {page_id}: {e}")
                 return
 
-def update_notion_page_status(page_id: str, status: str) -> bool:
+def update_page_checkbox(page_id: str, property_name: str, checked: bool) -> bool:
     """
-    Updates the 'Status' property of a Notion page.
+    Updates a checkbox property of a Notion page.
     Returns True on success, False on failure.
     """
     try:
-        # Check if the "Status" property exists before attempting to update
-        page = notion.pages.retrieve(page_id=page_id)
-        if "Status" not in page.get("properties", {}):
-            logging.error(f"Page {page_id} does not have a 'Status' property. Cannot update status.")
-            return False
-
-        properties = {"Status": {"select": {"name": status}}}
+        properties = {property_name: {"checkbox": checked}}
         notion.pages.update(page_id=page_id, properties=properties)
-        logging.info(f"✅ Updated status to '{status}' for page {page_id}")
+        logging.info(f"✅ Updated checkbox '{property_name}' to '{checked}' for page {page_id}")
         return True
     except Exception as e:
         # Log with traceback for better debugging
-        logging.error(f"❌ Failed to update status for page {page_id}: {e}", exc_info=True)
+        logging.error(f"❌ Failed to update checkbox for page {page_id}: {e}", exc_info=True)
         return False
 
 

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -236,14 +236,6 @@ def determine_workflow_type(page_id):
         parent_db_id = page.get("parent", {}).get("database_id", "").replace("-", "")
         logging.info(f"Checking parent DB ID: {parent_db_id}")
 
-        # Check for a "Status" property to prevent re-triggering completed workflows
-        status_prop = props.get("Status", {}).get("select", {})
-        current_status = status_prop.get("name") if status_prop else None
-
-        if current_status in ["In Progress", "Complete"]:
-            logging.info(f"Workflow for page {page_id} is already '{current_status}'. Skipping.")
-            return None
-
         # Dirty Clothes database workflows
         dirty_clothes_db_id = os.getenv("NOTION_DIRTY_CLOTHES_DB_ID", "").replace("-", "")
         if parent_db_id and parent_db_id == dirty_clothes_db_id:
@@ -366,13 +358,7 @@ def handle_outfit_workflow(page_id):
 def handle_travel_workflow(page_id):
     """Handle travel packing workflow with infinite loop prevention"""
     try:
-        from data.notion_utils import update_notion_page_status
         logging.info(f"🧳 ENTERING handle_travel_workflow for page {page_id}")
-        
-        # Set status to "In Progress" to lock the page from re-triggering
-        if not update_notion_page_status(page_id, "In Progress"):
-            logging.error(f"CRITICAL: Failed to set 'In Progress' status for page {page_id}. Aborting.")
-            return jsonify({"error": "Failed to set 'In Progress' status, aborting to prevent loop."}), 500
         
         # Extract travel trigger data with debugging
         logging.info(f"🧳 About to call get_travel_trigger_data")
@@ -380,7 +366,6 @@ def handle_travel_workflow(page_id):
         
         if not travel_trigger_data:
             logging.error("❌ Failed to extract travel trigger data")
-            update_notion_page_status(page_id, "Error")
             return jsonify({"error": "Failed to extract travel trigger data"}), 400
         
         logging.info(f"✅ Travel trigger data extracted: {travel_trigger_data}")
@@ -390,7 +375,6 @@ def handle_travel_workflow(page_id):
         travel_orchestrator = core_functions.get('travel_pipeline_orchestrator')
         
         if not travel_orchestrator:
-            update_notion_page_status(page_id, "Error")
             return jsonify({"error": "Travel pipeline not available"}), 500
         
         # Test orchestrator access
@@ -400,7 +384,6 @@ def handle_travel_workflow(page_id):
             logging.info(f"🧳 Orchestrator has run_travel_packing_pipeline method: {test_result}")
         except Exception as e:
             logging.error(f"❌ Orchestrator access test failed: {e}")
-            update_notion_page_status(page_id, "Error")
             return jsonify({"error": f"Orchestrator access failed: {str(e)}"}), 500
         
         logging.info(f"🧳 Starting async travel pipeline...")
@@ -658,10 +641,6 @@ def run_async_travel_pipeline(travel_orchestrator, trigger_data):
     
     except Exception as e:
         logging.error(f"Error in async travel pipeline: {e}", exc_info=True)
-        # Set status to "Error" on failure
-        if page_id:
-            from data.notion_utils import update_notion_page_status
-            update_notion_page_status(page_id, "Error")
         return {"success": False, "error": str(e)}
 
 


### PR DESCRIPTION
The travel packing agent pipeline was crashing because it was trying to update a 'Status' property that did not exist on the Notion page. The user indicated that the workflow should be triggered by a 'Generate' checkbox instead.

This commit refactors the status handling logic to use the 'Generate' checkbox as the primary trigger and state indicator.

Changes include:
- Replaced `update_notion_page_status` with a new `update_page_checkbox` function in `data/notion_utils.py`.
- Removed all logic related to the 'Status' property from `services/webhook_server.py`. The workflow no longer attempts to set an 'In Progress' status.
- Updated `core/notion_result_publisher.py` to uncheck the 'Generate' checkbox upon successful completion or on error, preventing the workflow from being re-triggered.