### PR TITLE
feat: Implement status-based loop prevention for all pipelines

### DIFF
--- a/core/hamper_pipeline_orchestrator.py
+++ b/core/hamper_pipeline_orchestrator.py
@@ -3,7 +3,8 @@ from data.notion_utils import (
     get_checked_items_from_page,
     add_items_to_dirty_clothes_db,
     uncheck_hamper_trigger,
-    update_clothing_washed_status
+    update_clothing_washed_status,
+    update_page_status,
 )
 
 class HamperPipelineOrchestrator:
@@ -20,6 +21,7 @@ class HamperPipelineOrchestrator:
         """
         try:
             logging.info(f"🧺 Starting 'Send to Hamper' pipeline for page {page_id}...")
+            update_page_status(page_id, "In Progress")
 
             # 1. Get checked items from the page (with validation)
             checked_items = get_checked_items_from_page(page_id)
@@ -29,7 +31,7 @@ class HamperPipelineOrchestrator:
                 logging.warning("- Checked items are not from the wardrobe database")
                 logging.warning("- Checked items are not valid page mentions")
                 # Still need to uncheck the trigger
-                uncheck_hamper_trigger(page_id)
+                update_page_status(page_id, "Complete")
                 return {"success": True, "message": "No valid wardrobe items to send to hamper."}
 
             logging.info(f"Processing {len(checked_items)} valid wardrobe items for hamper workflow")
@@ -38,7 +40,7 @@ class HamperPipelineOrchestrator:
             add_items_to_dirty_clothes_db(checked_items, page_id)
 
             # 3. Uncheck the "Send to Hamper" trigger
-            uncheck_hamper_trigger(page_id)
+            update_page_status(page_id, "Complete")
 
             logging.info(f"✅ 'Send to Hamper' pipeline completed successfully for page {page_id}.")
             return {"success": True, "processed_items": len(checked_items)}
@@ -47,7 +49,7 @@ class HamperPipelineOrchestrator:
             logging.error(f"❌ Critical pipeline error in 'Send to Hamper' pipeline: {str(e)}", exc_info=True)
             # It's important to still try and uncheck the trigger to prevent re-triggering.
             try:
-                uncheck_hamper_trigger(page_id)
+                update_page_status(page_id, "Failed")
                 logging.info(f"Unchecked hamper trigger for page {page_id} after error.")
             except Exception as uncheck_e:
                 logging.error(f"Failed to uncheck hamper trigger for page {page_id} after error: {uncheck_e}", exc_info=True)

--- a/core/outfit_pipeline_orchestrator.py
+++ b/core/outfit_pipeline_orchestrator.py
@@ -14,7 +14,8 @@ from data.notion_utils import (
     OUTPUT_DB_ID,
     get_checked_items_from_page,
     create_page_in_dirty_clothes_db,
-    update_wardrobe_item_status
+    update_wardrobe_item_status,
+    update_page_status,
 )
 
 
@@ -46,8 +47,12 @@ class OutfitPipelineOrchestrator:
         """
         Main pipeline execution for generating a daily outfit.
         """
+        output_page_id = get_output_page_id(OUTPUT_DB_ID)
+        if not output_page_id:
+            return {"success": False, "error": "Could not find the output page in Notion."}
         try:
             logging.info("👕 Starting daily outfit pipeline...")
+            update_page_status(output_page_id, "In Progress")
 
             # 1. Get user preferences from Notion
             selected_aesthetics = get_selected_aesthetic_from_output_db(OUTPUT_DB_ID)
@@ -69,13 +74,10 @@ class OutfitPipelineOrchestrator:
             result = await outfit_planner_agent.generate_outfit(context)
 
             if not result["success"]:
+                update_page_status(output_page_id, "Failed")
                 return result
 
             # 5. Post outfit to Notion
-            output_page_id = get_output_page_id(OUTPUT_DB_ID)
-            if not output_page_id:
-                return {"success": False, "error": "Could not find the output page in Notion."}
-
             clear_page_content(output_page_id)
             post_outfit_to_notion_page(output_page_id, result["outfit"])
 
@@ -85,13 +87,15 @@ class OutfitPipelineOrchestrator:
                 outfit_log_id=output_page_id
             )
 
-            clear_trigger_fields(output_page_id)
+            update_page_status(output_page_id, "Complete")
 
             logging.info("✅ Daily outfit pipeline completed successfully.")
             return {"success": True}
 
         except Exception as e:
             logging.error(f"❌ Critical pipeline error in daily outfit pipeline: {str(e)}", exc_info=True)
+            if output_page_id:
+                update_page_status(output_page_id, "Failed")
             return {"success": False, "error": f"Critical pipeline error: {str(e)}"}
 
 outfit_pipeline_orchestrator = OutfitPipelineOrchestrator()

--- a/services/webhook_server.py
+++ b/services/webhook_server.py
@@ -279,6 +279,11 @@ def determine_workflow_type(page_id):
             t.get("plain_text", "").strip() for t in prompt_prop.get("rich_text", [])
         )
         if has_aesthetic and has_prompt:
+            status_prop = props.get("Status", {})
+            current_status = status_prop.get("select", {}).get("name")
+            if current_status in ["In Progress", "Complete"]:
+                logging.info(f"Outfit workflow for page {page_id} skipped, status is '{current_status}'.")
+                return None
             logging.info("👕 Outfit trigger detected.")
             return "outfit"
 
@@ -297,6 +302,11 @@ def determine_workflow_type(page_id):
                 logging.error(f"Error checking hamper to-do block: {e}")
             logging.info(f"Hamper property checked={prop_checked}, hamper to-do checked={has_checked_block}")
             if prop_checked or has_checked_block:
+                status_prop = props.get("Status", {})
+                current_status = status_prop.get("select", {}).get("name")
+                if current_status in ["In Progress", "Complete"]:
+                    logging.info(f"Hamper workflow for page {page_id} skipped, status is '{current_status}'.")
+                    return None
                 logging.info("🧺 Hamper trigger detected.")
                 return "hamper"
 

--- a/tests/test_hamper_pipeline.py
+++ b/tests/test_hamper_pipeline.py
@@ -11,8 +11,8 @@ def mock_add_to_db(mocker):
     return mocker.patch('core.hamper_pipeline_orchestrator.add_items_to_dirty_clothes_db')
 
 @pytest.fixture
-def mock_uncheck_trigger(mocker):
-    return mocker.patch('core.hamper_pipeline_orchestrator.uncheck_hamper_trigger')
+def mock_update_page_status(mocker):
+    return mocker.patch('core.hamper_pipeline_orchestrator.update_page_status')
 
 @pytest.fixture
 def mock_update_washed_status(mocker):
@@ -23,7 +23,7 @@ def hamper_orchestrator():
     return HamperPipelineOrchestrator()
 
 @pytest.mark.asyncio
-async def test_run_hamper_pipeline_success(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+async def test_run_hamper_pipeline_success(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_update_page_status):
     """
     Tests that the hamper pipeline runs successfully.
     """
@@ -35,10 +35,13 @@ async def test_run_hamper_pipeline_success(hamper_orchestrator, mock_get_checked
     assert result["processed_items"] == 1
     mock_get_checked_items.assert_called_once_with(page_id)
     mock_add_to_db.assert_called_once_with([{"id": "item1", "name": "T-shirt"}], page_id)
-    mock_uncheck_trigger.assert_called_once_with(page_id)
+    mock_update_page_status.assert_has_calls([
+        call(page_id, "In Progress"),
+        call(page_id, "Complete")
+    ])
 
 @pytest.mark.asyncio
-async def test_run_hamper_pipeline_no_items(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+async def test_run_hamper_pipeline_no_items(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_update_page_status):
     """
     Tests that the hamper pipeline handles the case where there are no valid items to process.
     """
@@ -51,10 +54,13 @@ async def test_run_hamper_pipeline_no_items(hamper_orchestrator, mock_get_checke
     assert result["message"] == "No valid wardrobe items to send to hamper."
     mock_get_checked_items.assert_called_once_with(page_id)
     mock_add_to_db.assert_not_called()
-    mock_uncheck_trigger.assert_called_once_with(page_id)
+    mock_update_page_status.assert_has_calls([
+        call(page_id, "In Progress"),
+        call(page_id, "Complete")
+    ])
 
 @pytest.mark.asyncio
-async def test_run_hamper_pipeline_error(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_uncheck_trigger):
+async def test_run_hamper_pipeline_error(hamper_orchestrator, mock_get_checked_items, mock_add_to_db, mock_update_page_status):
     """
     Tests that the hamper pipeline handles errors gracefully.
     """
@@ -67,7 +73,10 @@ async def test_run_hamper_pipeline_error(hamper_orchestrator, mock_get_checked_i
     assert "Test error" in result["error"]
     mock_get_checked_items.assert_called_once_with(page_id)
     mock_add_to_db.assert_not_called()
-    mock_uncheck_trigger.assert_called_once_with(page_id)
+    mock_update_page_status.assert_has_calls([
+        call(page_id, "In Progress"),
+        call(page_id, "Failed")
+    ])
 
 @pytest.mark.asyncio 
 async def test_dirty_clothes_workflow_integration():


### PR DESCRIPTION
This commit introduces a standardized, status-based loop prevention mechanism across all data pipelines to prevent the infinite loops that were occurring due to the previous brittle trigger-clearing mechanisms.

The key changes are:
- The `outfit` and `hamper` pipelines now use a "Status" property on the Notion page to track their state ("In Progress", "Complete", "Failed").
- The webhook server now checks this "Status" property before triggering the `outfit` and `hamper` workflows, preventing them from running if they are already in progress or complete.
- The old, brittle trigger-clearing mechanisms (clearing fields, unchecking boxes) have been removed from the `outfit` and `hamper` pipelines.
- The unit tests for the `hamper` pipeline have been updated to reflect these changes.